### PR TITLE
Fix#25 : find_roots_eigen Not Working for Polynomial of Degree 4 or More

### DIFF
--- a/src/numerical/eigen.rs
+++ b/src/numerical/eigen.rs
@@ -699,7 +699,7 @@ mod test {
     #[test]
     fn test_find_roots_eigen_asymetric() {
         let roots = find_roots_eigen(vec![1f64, 2f64, 3f64]);
-        dbg!(&roots);
+        // (According to Wolfram Alpha, roots must be -1.275682203650984989057077)
         assert_eq!(roots[0], -1.2756822036509838f64);
     }
 


### PR DESCRIPTION
I found an error in the creation of the matrix of the polynomial. It reverses the order of the coefficients. I have corrected it and now it works correctly. I specify in the function documentation the order of the coefficients like find_roots_sturm.

There were multiple tests with bad results. It seems to be due to the same error, so I corrected them.

On the other hand, I did personally some benchmarks of eigen and sturm to compare. Sturm is faster by a factor of 10 in my case without a loss of accuracy. I think it doesn't make sense to use the eigen function for real roots, but the eigen function could be useful to find the complex roots. Maybe changing the output should be a good idea.