### PR TITLE
Make search error copy and clone

### DIFF
--- a/src/numerical/mod.rs
+++ b/src/numerical/mod.rs
@@ -99,7 +99,7 @@ where
 }
 
 /// Possible errors
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum SearchError {
     /// The algorithm could not converge within the given number of iterations
     NoConvergency,


### PR DESCRIPTION
Zero cost copy since it's a simple untagged enum.

Useful in my case because I'm using thiserror and my thiserror enum itself is clonable.